### PR TITLE
refactor(api): use core.GetAPIConfig to retrieve plugin configuration

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -71,10 +71,10 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 }
 
 func (a *API) Configure(gRouter router.Router, _ core.AccessService) error {
-	cfg := a.config.GetAPI(internal.PLUGIN_NAME).(*pluginConfig.APIConfig)
+	cfg := core.GetAPIConfig[*pluginConfig.APIConfig](a.ctx, internal.PLUGIN_NAME)
 
 	var fsHandler fs.FS
-	if cfg.GitRepo != "" {
+	if cfg != nil && cfg.GitRepo != "" {
 		handler, err := a.createGitHubFS(cfg.GitRepo)
 		if err != nil {
 			return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,8 +4,6 @@ import (
 	"go.lumeweb.com/portal/config"
 )
 
-const PLUGIN_NAME = "frontend"
-
 var _ config.APIConfig = (*APIConfig)(nil)
 
 type APIConfig struct {


### PR DESCRIPTION
- Replace direct config access with core.GetAPIConfig for better type safety
- Add nil check for config before accessing GitRepo field