### PR TITLE
ci: simplify release workflow to use centralized template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,28 +3,8 @@ name: Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.PAT }}
-
-      - name: Install Knope
-        uses: knope-dev/action@v2.1.0
-        with:
-          version: 0.21.7
-
-      - name: Setup Git
-        uses: LumeWeb/workflows/.github/actions/setup-git@develop
-
-      - name: Create Release
-        run: knope release --verbose
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+    uses: LumeWeb/workflows/.github/workflows/release.yml@develop
+    secrets:
+      PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
- Replace custom implementation with LumeWeb/workflows/.github/workflows/release.yml@develop
- Remove redundant permissions declaration
- Consolidate workflow logic into centralized reusable workflow


---

<!-- kody-pr-summary:start -->
This pull request simplifies the GitHub Actions release workflow by replacing the locally defined job steps with a call to a centralized reusable workflow from the `LumeWeb/workflows` repository. The specific implementation details for checking out code, installing dependencies, and creating releases are now handled by the external template, reducing the complexity of the local workflow file.
<!-- kody-pr-summary:end -->