### PR TITLE
ci: add secrets inherit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,3 +9,4 @@ on:
 jobs:
   build:
     uses: LumeWeb/workflows/.github/workflows/build-plugin.yml@develop
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,5 +6,4 @@ on:
 jobs:
   release:
     uses: LumeWeb/workflows/.github/workflows/release.yml@develop
-    secrets:
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit

--- a/.github/workflows/update-ui.yml
+++ b/.github/workflows/update-ui.yml
@@ -15,5 +15,4 @@ jobs:
       commit_hash: ${{ github.event.client_payload.commit_hash }}
       app_name: ${{ github.event.client_payload.app_name }}
       repository: ${{ github.event.client_payload.repository }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the GitHub Actions workflow configurations to automatically pass all repository secrets to the reusable workflows. Specifically, it modifies the `build`, `release`, and `update-ui` workflows to use the `secrets: inherit` directive. This replaces the previous method of explicitly passing specific secrets (such as `PAT`) or not passing them at all, ensuring that the called workflows have access to the necessary credentials without manual mapping.
<!-- kody-pr-summary:end -->