### PR TITLE
feat: add gateway proxy mode for IPFS website serving

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	_ "embed"
 	"fmt"
 	"io"
 	"io/fs"
@@ -18,7 +17,7 @@ import (
 	"github.com/google/go-github/v50/github"
 	"go.lumeweb.com/portal-plugin-frontend/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-frontend/internal/config"
-	"go.lumeweb.com/portal-router"
+	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	portal_frontend "go.lumeweb.com/web/go/portal-frontend"
@@ -62,19 +61,26 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 func (a *API) Configure(gRouter router.Router, _ core.AccessService) error {
 	cfg := core.GetAPIConfig[*pluginConfig.APIConfig](a.Context(), internal.PLUGIN_NAME)
 
-	var fsHandler fs.FS
-	if cfg != nil && cfg.GitRepo != "" {
-		handler, err := a.createGitHubFS(cfg.GitRepo)
-		if err != nil {
-			return err
+	if cfg != nil {
+		if cfg.Gateway != "" {
+			proxy, err := a.createGatewayProxy(cfg.Gateway)
+			if err != nil {
+				return err
+			}
+			return router.SetupStaticRoutes(gRouter, router.StaticConfig{DefaultHandler: proxy})
 		}
-		fsHandler = handler
-	} else {
-		fsHandler = portal_frontend.GetFS()
+
+		if cfg.GitRepo != "" {
+			fsHandler, err := a.createGitHubFS(cfg.GitRepo)
+			if err != nil {
+				return err
+			}
+			router.MustMPASetupWithAssets(gRouter, fsHandler, AstroAssetsDir)
+			return nil
+		}
 	}
 
-	// Ensure fsHandler is rooted at the app directory (e.g., <ziproot>/dist when using Astro)
-	router.MustMPASetupWithAssets(gRouter, fsHandler, AstroAssetsDir)
+	router.MustMPASetupWithAssets(gRouter, portal_frontend.GetFS(), AstroAssetsDir)
 	return nil
 }
 

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func newGatewayProxy(gatewayURL string, logger *zap.Logger) (http.Handler, error) {
+	target, err := url.Parse(gatewayURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid gateway URL: %w", err)
+	}
+
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			originalHost := req.Host
+
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = target.Host
+
+			req.Header.Del("X-Forwarded-Host")
+			req.Header.Set("X-Forwarded-Host", originalHost)
+
+			clientIP, _, err := net.SplitHostPort(req.RemoteAddr)
+			if err != nil {
+				clientIP = req.RemoteAddr
+			}
+
+			if prior := req.Header.Get("X-Forwarded-For"); prior != "" {
+				req.Header.Set("X-Forwarded-For", prior+", "+clientIP)
+			} else {
+				req.Header.Set("X-Forwarded-For", clientIP)
+			}
+		},
+		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
+			logger.Error("gateway proxy error", zap.Error(err))
+
+			if os.IsTimeout(err) {
+				http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
+				return
+			}
+
+			http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		},
+		Transport: transport,
+	}
+
+	return proxy, nil
+}
+
+func (a *API) createGatewayProxy(gatewayURL string) (http.Handler, error) {
+	return newGatewayProxy(gatewayURL, a.Logger().Logger)
+}

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -34,6 +35,8 @@ func newGatewayProxy(gatewayURL string, logger *zap.Logger) (http.Handler, error
 
 			req.URL.Scheme = target.Scheme
 			req.URL.Host = target.Host
+			req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+			req.URL.RawPath = singleJoiningSlash(target.RawPath, req.URL.RawPath)
 			req.Host = target.Host
 
 			req.Header.Del("X-Forwarded-Host")
@@ -44,11 +47,8 @@ func newGatewayProxy(gatewayURL string, logger *zap.Logger) (http.Handler, error
 				clientIP = req.RemoteAddr
 			}
 
-			if prior := req.Header.Get("X-Forwarded-For"); prior != "" {
-				req.Header.Set("X-Forwarded-For", prior+", "+clientIP)
-			} else {
-				req.Header.Set("X-Forwarded-For", clientIP)
-			}
+			req.Header.Del("X-Forwarded-For")
+			req.Header.Set("X-Forwarded-For", clientIP)
 		},
 		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
 			logger.Error("gateway proxy error", zap.Error(err))
@@ -68,4 +68,16 @@ func newGatewayProxy(gatewayURL string, logger *zap.Logger) (http.Handler, error
 
 func (a *API) createGatewayProxy(gatewayURL string) (http.Handler, error) {
 	return newGatewayProxy(gatewayURL, a.Logger().Logger)
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
 }

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -101,7 +102,7 @@ func TestNewGatewayProxy_StripSpoofedForwardedHost(t *testing.T) {
 	}
 }
 
-func TestNewGatewayProxy_AppendForwardedFor(t *testing.T) {
+func TestNewGatewayProxy_StripSpoofedForwardedFor(t *testing.T) {
 	var receivedForwardedFor string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedForwardedFor = r.Header.Get("X-Forwarded-For")
@@ -125,10 +126,42 @@ func TestNewGatewayProxy_AppendForwardedFor(t *testing.T) {
 	rec := httptest.NewRecorder()
 	frontend.Config.Handler.ServeHTTP(rec, req)
 
-	if !strings.Contains(receivedForwardedFor, "9.9.9.9") {
-		t.Errorf("X-Forwarded-For = %q, want it to contain %q", receivedForwardedFor, "9.9.9.9")
+	if strings.Contains(receivedForwardedFor, "9.9.9.9") {
+		t.Errorf("X-Forwarded-For = %q, should not contain spoofed %q", receivedForwardedFor, "9.9.9.9")
 	}
 	if !strings.Contains(receivedForwardedFor, "10.0.0.1") {
 		t.Errorf("X-Forwarded-For = %q, want it to contain %q", receivedForwardedFor, "10.0.0.1")
+	}
+}
+
+func TestNewGatewayProxy_PathPrefixJoining(t *testing.T) {
+	var receivedPath string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	gatewayURL := backendURL.Scheme + "://" + backendURL.Host + "/ipfs/QmHash"
+
+	proxy, err := newGatewayProxy(gatewayURL, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newGatewayProxy: %v", err)
+	}
+
+	frontend := httptest.NewServer(proxy)
+	defer frontend.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/index.html", nil)
+	req.Host = "example.com"
+	req.RemoteAddr = "10.0.0.1:1234"
+
+	rec := httptest.NewRecorder()
+	frontend.Config.Handler.ServeHTTP(rec, req)
+
+	want := "/ipfs/QmHash/index.html"
+	if receivedPath != want {
+		t.Errorf("path = %q, want %q", receivedPath, want)
 	}
 }

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewGatewayProxy_InvalidURL(t *testing.T) {
+	_, err := newGatewayProxy("://bad", zap.NewNop())
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestNewGatewayProxy_ProxiesRequest(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Got-Host", r.Host)
+		w.Header().Set("X-Got-X-Forwarded-Host", r.Header.Get("X-Forwarded-Host"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	proxy, err := newGatewayProxy(backend.URL, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newGatewayProxy: %v", err)
+	}
+
+	frontend := httptest.NewServer(proxy)
+	defer frontend.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/test-path", nil)
+	req.Host = "example.com"
+	req.RemoteAddr = "1.2.3.4:5678"
+
+	rec := httptest.NewRecorder()
+	frontend.Config.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	if got := rec.Header().Get("X-Got-X-Forwarded-Host"); got != "example.com" {
+		t.Errorf("X-Forwarded-Host = %q, want %q", got, "example.com")
+	}
+
+	if got := rec.Header().Get("X-Got-Host"); got != backend.Listener.Addr().String() {
+		t.Errorf("Host = %q, want %q", got, backend.Listener.Addr().String())
+	}
+}
+
+func TestNewGatewayProxy_BadGateway(t *testing.T) {
+	proxy, err := newGatewayProxy("http://127.0.0.1:1", zap.NewNop())
+	if err != nil {
+		t.Fatalf("newGatewayProxy: %v", err)
+	}
+
+	frontend := httptest.NewServer(proxy)
+	defer frontend.Close()
+
+	resp, err := http.Get(frontend.URL + "/test")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", resp.StatusCode)
+	}
+}
+
+func TestNewGatewayProxy_StripSpoofedForwardedHost(t *testing.T) {
+	var receivedForwardedHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedForwardedHost = r.Header.Get("X-Forwarded-Host")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	proxy, err := newGatewayProxy(backend.URL, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newGatewayProxy: %v", err)
+	}
+
+	frontend := httptest.NewServer(proxy)
+	defer frontend.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "real.example.com"
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-Host", "spoofed.example.com")
+
+	rec := httptest.NewRecorder()
+	frontend.Config.Handler.ServeHTTP(rec, req)
+
+	if receivedForwardedHost != "real.example.com" {
+		t.Errorf("X-Forwarded-Host = %q, want %q (spoofed value should be stripped)", receivedForwardedHost, "real.example.com")
+	}
+}
+
+func TestNewGatewayProxy_AppendForwardedFor(t *testing.T) {
+	var receivedForwardedFor string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedForwardedFor = r.Header.Get("X-Forwarded-For")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	proxy, err := newGatewayProxy(backend.URL, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newGatewayProxy: %v", err)
+	}
+
+	frontend := httptest.NewServer(proxy)
+	defer frontend.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "9.9.9.9")
+
+	rec := httptest.NewRecorder()
+	frontend.Config.Handler.ServeHTTP(rec, req)
+
+	if !strings.Contains(receivedForwardedFor, "9.9.9.9") {
+		t.Errorf("X-Forwarded-For = %q, want it to contain %q", receivedForwardedFor, "9.9.9.9")
+	}
+	if !strings.Contains(receivedForwardedFor, "10.0.0.1") {
+		t.Errorf("X-Forwarded-For = %q, want it to contain %q", receivedForwardedFor, "10.0.0.1")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"net/url"
+
 	"go.lumeweb.com/portal/config"
 )
 
@@ -8,8 +11,25 @@ var _ config.APIConfig = (*APIConfig)(nil)
 
 type APIConfig struct {
 	GitRepo string `config:"git_repo"`
+	Gateway string `config:"gateway"`
 }
 
 func (A APIConfig) Defaults() map[string]any {
 	return map[string]any{}
+}
+
+func (A APIConfig) Validate() error {
+	if A.Gateway != "" && A.GitRepo != "" {
+		return fmt.Errorf("gateway and git_repo are mutually exclusive — set only one")
+	}
+	if A.Gateway != "" {
+		u, err := url.Parse(A.Gateway)
+		if err != nil {
+			return fmt.Errorf("gateway must be a valid URL with scheme and host")
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return fmt.Errorf("gateway must be a valid URL with scheme and host")
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Add a 'gateway' config option that reverse-proxies non-API requests to an IPFS website gateway service. When enabled, the embedded/GitHub static website is not served; instead all non-/api/* traffic is proxied with X-Forwarded-Host preservation for gateway domain resolution.

- Gateway string config field (mutually exclusive with git_repo)
- newGatewayProxy() with httputil.ReverseProxy, X-Forwarded-Host/For
- 3-way Configure() dispatch: gateway > github > embedded
- Integration tests using httptest.Server

---

<!-- kody-pr-summary:start -->
Add gateway proxy mode for serving frontend content via an external gateway URL

This PR introduces a new `gateway` configuration option that allows the frontend plugin to act as a reverse proxy to an external gateway (e.g., an IPFS gateway for serving websites), instead of serving content from embedded assets or a Git repository.

Key changes:
- **New `gateway` config option**: Mutually exclusive with the existing `git_repo` option; validated to require a valid URL with scheme and host
- **Reverse proxy implementation**: Forwards all requests to the configured gateway URL with proper `X-Forwarded-Host` (stripping any spoofed values) and `X-Forwarded-For` header handling, appropriate transport timeouts, and error responses (502 Bad Gateway / 504 Gateway Timeout)
- **Configuration priority**: Gateway mode takes precedence over GitRepo mode, which takes precedence over the default embedded frontend assets
<!-- kody-pr-summary:end -->