### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/initial_version.md
+++ b/.changeset/initial_version.md
@@ -1,0 +1,5 @@
+---
+default: major
+---
+
+# Initial version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module go.lumeweb.com/portal-plugin-frontend
+module go.lumeweb.com/portal-plugin-frontend // v0.0.0
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-github/v50 v50.2.0


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add initial changeset for major version release

This PR introduces a changeset file to track the initial version of the package. The changeset specifies a major version bump (`default: major`) with the description "Initial version", which will result in the package being published at version 1.0.0 (or its first major release).
<!-- kody-pr-summary:end -->